### PR TITLE
Updated dependencies to replace environment_factors.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ repositories {
             maven {
                 name = 'GeckoLib'
                 url = 'https://dl.cloudsmith.io/public/geckolib3/geckolib/maven/'
+                content {
+                    includeGroup("software.bernie.geckolib")
+                }
             }
         }
         filter { 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 mod_name=Dynamic Trees BWG
 mod_id=dtbwg
-mod_version=1.1.0-BETA02
+mod_version=1.1.0-BETA03
 mod_group_id=maxhyper.dtbwg
 mod_license=MIT
 mod_credits=GroupiX05, metafive

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,19 +19,19 @@ neo_version=21.1.208
 loader_version_range=[1,)
 
 # Dynamic Trees
-dynamic_trees_version=1.5.0-BETA13
-dynamic_trees_plus_version=1.3.0-BETA03
+dynamic_trees_version=1.7.2
+dynamic_trees_plus_version=1.3.2
 
 # Utilities
-jade_version=15.10.3
-jei_version=19.25.0.325
-cc_version=1.116.2
+jade_version=15.10.5
+jei_version=19.39.0.371
+cc_version=1.120.0
 
 # Addon
-bwg_version=2.5.0
-ohthetreesyoullgrow_version=5.1.2
-geckolib_version=4.7.7
-corgilib_version=5.0.0.7
+bwg_version=2.6.0
+ohthetreesyoullgrow_version=5.3.2
+geckolib_version=4.9.2
+corgilib_version=5.0.0.9
 terrablender_version=4.1.0.8
 
 versionType=beta

--- a/src/main/java/maxhyper/dtbwg/blocks/EmburGelCapProperties.java
+++ b/src/main/java/maxhyper/dtbwg/blocks/EmburGelCapProperties.java
@@ -41,7 +41,7 @@ public class EmburGelCapProperties extends CapProperties {
     }
 
     @Override
-    public BlockBehaviour.Properties getDefaultBlockProperties(MapColor mapColor) {
+    public BlockBehaviour.Properties getDefaultBlockProperties() {
         return BlockBehaviour.Properties.ofFullCopy(Blocks.CLAY).mapColor(MapColor.TERRACOTTA_YELLOW).sound(SoundType.HONEY_BLOCK).noOcclusion().speedFactor(1.3f);
     }
 

--- a/src/main/java/maxhyper/dtbwg/blocks/WartyCapProperties.java
+++ b/src/main/java/maxhyper/dtbwg/blocks/WartyCapProperties.java
@@ -67,9 +67,9 @@ public class WartyCapProperties extends CapProperties {
    }
 
    @Override
-   public BlockBehaviour.Properties getDefaultBlockProperties(final MapColor mapColor) {
+   public BlockBehaviour.Properties getDefaultBlockProperties() {
        return BlockBehaviour.Properties.of()
-                .mapColor(mapColor.GRASS)
+                .mapColor(MapColor.GRASS)
                 .strength(1.0F)
                 .sound(SoundType.WART_BLOCK);
    }

--- a/src/main/resources/trees/dtbwg/families/palm.json
+++ b/src/main/resources/trees/dtbwg/families/palm.json
@@ -1,5 +1,5 @@
 {
-  "type": "dtbwg:diagonal_palm",
+  "type": "palm",
   "common_leaves": "dtbwg:palm",
   "common_species": "dtbwg:palm",
   "primitive_log": "biomeswevegone:palm_log",

--- a/src/main/resources/trees/dtbwg/leaves_properties/mega_palm.json
+++ b/src/main/resources/trees/dtbwg/leaves_properties/mega_palm.json
@@ -1,7 +1,7 @@
 {
   "type": "palm",
   "primitive_leaves": "biomeswevegone:palm_leaves",
-  "cell_kit": "dtbwg:palm",
+  "cell_kit": "dynamictrees:palm",
   "color": "#BBFF59",
   "model_overrides": {
     "leaves": "biomeswevegone:block/palm_leaves"

--- a/src/main/resources/trees/dtbwg/leaves_properties/palm.json
+++ b/src/main/resources/trees/dtbwg/leaves_properties/palm.json
@@ -1,7 +1,7 @@
 {
   "type": "palm",
   "primitive_leaves": "biomeswevegone:palm_leaves",
-  "cell_kit": "dtbwg:palm",
+  "cell_kit": "dynamictrees:palm",
   "color": "#BBFF59",
   "model_overrides": {
     "leaves": "biomeswevegone:block/palm_leaves"

--- a/src/main/resources/trees/dtbwg/species/ancient_birch.json
+++ b/src/main/resources/trees/dtbwg/species/ancient_birch.json
@@ -9,12 +9,8 @@
   "max_branch_radius": 24,
   "leaves_properties": "birch",
   "growth_logic_kit": "dtbwg:ancient",
-  "environment_factors": {
-    "cold": 0.9,
-    "hot": 0.9,
-    "dry": 0.8,
-    "magical": 1.1
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.5,
   "perfect_biomes": {
     "name": "biomeswevegone:overgrowth_woodlands"
   },

--- a/src/main/resources/trees/dtbwg/species/ancient_dark_oak.json
+++ b/src/main/resources/trees/dtbwg/species/ancient_dark_oak.json
@@ -9,12 +9,8 @@
   "max_branch_radius": 24,
   "leaves_properties": "dark_oak",
   "growth_logic_kit": "dtbwg:ancient",
-  "environment_factors": {
-    "cold": 0.9,
-    "hot": 0.9,
-    "dry": 0.8,
-    "magical": 1.1
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.6,
   "perfect_biomes": {
     "name": "biomeswevegone:forgotten_forest"
   },

--- a/src/main/resources/trees/dtbwg/species/ancient_ebony.json
+++ b/src/main/resources/trees/dtbwg/species/ancient_ebony.json
@@ -9,12 +9,8 @@
   "max_branch_radius": 24,
   "leaves_properties": "dtbwg:ancient_ebony",
   "growth_logic_kit": "dtbwg:ancient",
-  "environment_factors": {
-    "cold": 0.9,
-    "hot": 0.9,
-    "dry": 0.8,
-    "magical": 1.1
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.6,
   "perfect_biomes": {
     "name": "biomeswevegone:forgotten_forest"
   },

--- a/src/main/resources/trees/dtbwg/species/ancient_oak.json
+++ b/src/main/resources/trees/dtbwg/species/ancient_oak.json
@@ -9,12 +9,8 @@
   "max_branch_radius": 24,
   "leaves_properties": "dtbwg:ancient_oak",
   "growth_logic_kit": "dtbwg:ancient",
-  "environment_factors": {
-    "cold": 0.9,
-    "hot": 0.9,
-    "dry": 0.8,
-    "magical": 1.1
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.5,
   "perfect_biomes": {
     "name": "biomeswevegone:forgotten_forest"
   },

--- a/src/main/resources/trees/dtbwg/species/ancient_silver_maple.json
+++ b/src/main/resources/trees/dtbwg/species/ancient_silver_maple.json
@@ -10,12 +10,8 @@
   "leaves_properties": "dtbwg:ancient_silver_maple",
   "growth_logic_kit": "dtbwg:ancient",
   "seed": "dtbwg:silver_maple_seed",
-  "environment_factors": {
-    "cold": 0.9,
-    "hot": 0.9,
-    "dry": 0.8,
-    "magical": 1.1
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.5,
   "perfect_biomes": {
     "name": "biomeswevegone:forgotten_forest"
   },

--- a/src/main/resources/trees/dtbwg/species/ancient_yellow_birch.json
+++ b/src/main/resources/trees/dtbwg/species/ancient_yellow_birch.json
@@ -10,12 +10,8 @@
   "leaves_properties": "dtbwg:yellow_birch",
   "seed": "dtbwg:yellow_birch_seed",
   "growth_logic_kit": "dtbwg:ancient",
-  "environment_factors": {
-    "cold": 0.9,
-    "hot": 0.9,
-    "dry": 0.8,
-    "magical": 1.1
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.5,
   "perfect_biomes": {
     "name": "biomeswevegone:overgrowth_woodlands"
   },

--- a/src/main/resources/trees/dtbwg/species/araucaria.json
+++ b/src/main/resources/trees/dtbwg/species/araucaria.json
@@ -11,10 +11,8 @@
   "generate_sapling": true,
   "growth_logic_kit": "dtbwg:araucaria",
   "leaves_properties": "dtbwg:araucaria",
-  "environment_factors": {
-    "wet": 0.75,
-    "cold": 0.50
-  },
+  "preferred_climate": "arid",
+  "climate_tolerance": 0.3,
   "common_override": {
     "name": "biomeswevegone:.*araucaria.*"
   },

--- a/src/main/resources/trees/dtbwg/species/aspen.json
+++ b/src/main/resources/trees/dtbwg/species/aspen.json
@@ -5,12 +5,8 @@
   "growth_rate": 0.8,
   "leaves_properties": "dtbwg:aspen",
   "growth_logic_kit": "dtbwg:aspen",
-  "environment_factors": {
-    "cold": 1.1,
-    "hot": 0.2,
-    "dry": 0.4,
-    "forest": 0.9
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": "biomeswevegone:aspen.*"
   },

--- a/src/main/resources/trees/dtbwg/species/baobab.json
+++ b/src/main/resources/trees/dtbwg/species/baobab.json
@@ -8,10 +8,8 @@
   "soil_longevity": 20,
   "max_branch_radius": 24,
   "leaves_properties": "dtbwg:baobab",
-  "environment_factors": {
-    "cold": 0.75,
-    "forest": 0.9
-  },
+  "preferred_climate": "arid",
+  "climate_tolerance": 0.5,
   "perfect_biomes": {
     "name": "biomeswevegone:.*baobab.*"
   },

--- a/src/main/resources/trees/dtbwg/species/blue_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/blue_spruce.json
@@ -7,11 +7,8 @@
   "leaves_properties": "dtbwg:blue_spruce",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": "biomeswevegone:frosted_taiga.*"
   },

--- a/src/main/resources/trees/dtbwg/species/brown_zelkova.json
+++ b/src/main/resources/trees/dtbwg/species/brown_zelkova.json
@@ -9,10 +9,8 @@
   "leaves_properties": "dtbwg:brown_zelkova",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors": {
-    "hot": 0.50,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "name": ".*zelkova.*"
   },

--- a/src/main/resources/trees/dtbwg/species/canopy_aspen.json
+++ b/src/main/resources/trees/dtbwg/species/canopy_aspen.json
@@ -7,12 +7,8 @@
   "soil_longevity": 2,
   "leaves_properties": "dtbwg:aspen",
   "growth_logic_kit": "dtbwg:aspen",
-  "environment_factors": {
-    "cold": 1.1,
-    "hot": 0.2,
-    "dry": 0.4,
-    "forest": 0.9
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "always_show_on_waila": false,
   "perfect_biomes": {
     "name": "biomeswevegone:aspen.*"

--- a/src/main/resources/trees/dtbwg/species/canopy_dark_oak.json
+++ b/src/main/resources/trees/dtbwg/species/canopy_dark_oak.json
@@ -7,12 +7,8 @@
   "growth_rate": 0.8,
   "leaves_properties": "dtbwg:canopy_dark_oak",
   "growth_logic_kit": "dtbwg:maple",
-  "environment_factors": {
-    "cold": 1.1,
-    "hot": 0.2,
-    "dry": 0.4,
-    "forest": 0.9
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": ".*meadow.*"
   },

--- a/src/main/resources/trees/dtbwg/species/canopy_oak.json
+++ b/src/main/resources/trees/dtbwg/species/canopy_oak.json
@@ -7,12 +7,8 @@
   "growth_rate": 0.8,
   "leaves_properties": "dtbwg:canopy_oak",
   "growth_logic_kit": "dtbwg:maple",
-  "environment_factors": {
-    "cold": 1.1,
-    "hot": 0.2,
-    "dry": 0.4,
-    "forest": 0.9
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": ".*meadow.*"
   },

--- a/src/main/resources/trees/dtbwg/species/cika.json
+++ b/src/main/resources/trees/dtbwg/species/cika.json
@@ -16,11 +16,8 @@
     }
   },
   "leaves_properties": "dtbwg:cika",
-  "environment_factors": {
-    "hot": 0.8,
-    "dry": 0.75,
-    "wet": 0.9
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.45,
   "always_show_on_waila": false,
   "world_gen_leaf_map_height": 60,
   "common_override": {

--- a/src/main/resources/trees/dtbwg/species/cypress.json
+++ b/src/main/resources/trees/dtbwg/species/cypress.json
@@ -11,16 +11,14 @@
   "world_gen_leaf_map_height": 64,
   "growth_logic_kit": "dtbwg:cypress",
   "leaves_properties": "dtbwg:cypress",
-  "environment_factors": {
-    "hot": 0.7,
-    "dry": 0.5
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
   "perfect_biomes": {
     "tags": [
       "#c:is_swamp",
       "#minecraft:is_overworld"
     ]
-  },
+    },
   "primitive_sapling": "biomeswevegone:cypress_sapling",
   "acceptable_soils": [
     "water_like",

--- a/src/main/resources/trees/dtbwg/species/ebony.json
+++ b/src/main/resources/trees/dtbwg/species/ebony.json
@@ -8,11 +8,8 @@
   "soil_longevity": 20,
   "leaves_properties": "dtbwg:ebony",
   "growth_logic_kit": "dtbwg:ebony",
-  "environment_factors": {
-    "cold": 0.9,
-    "hot": 0.75,
-    "dry": 0.8
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.5,
   "perfect_biomes": {
     "name": ".*ebony.*"
   },

--- a/src/main/resources/trees/dtbwg/species/fir.json
+++ b/src/main/resources/trees/dtbwg/species/fir.json
@@ -7,11 +7,8 @@
   "growth_rate": 0.9,
   "growth_logic_kit": "conifer",
   "leaves_properties": "dtbwg:fir",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "tag": "#c:is_coniferous"
   },

--- a/src/main/resources/trees/dtbwg/species/giga_blue_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/giga_blue_spruce.json
@@ -14,11 +14,8 @@
     }
   },
   "leaves_properties": "dtbwg:blue_spruce",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "world_gen_leaf_map_height": 70,
   "perfect_biomes": {
     "name": "biomeswevegone:frosted_taiga.*"

--- a/src/main/resources/trees/dtbwg/species/giga_orange_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/giga_orange_spruce.json
@@ -14,11 +14,8 @@
     }
   },
   "leaves_properties": "dtbwg:orange_spruce",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "world_gen_leaf_map_height": 70,
   "perfect_biomes": {
     "name": "biomeswevegone:.*crimson_tundra.*"

--- a/src/main/resources/trees/dtbwg/species/giga_red_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/giga_red_spruce.json
@@ -14,11 +14,8 @@
     }
   },
   "leaves_properties": "dtbwg:red_spruce",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "world_gen_leaf_map_height": 70,
   "perfect_biomes": {
     "name": "biomeswevegone:.*crimson_tundra.*"

--- a/src/main/resources/trees/dtbwg/species/giga_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/giga_spruce.json
@@ -14,11 +14,8 @@
     }
   },
   "leaves_properties": "spruce",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.35,
   "world_gen_leaf_map_height": 70,
   "common_override": {
     "name": "biomeswevegone:dacite_ridges"

--- a/src/main/resources/trees/dtbwg/species/giga_yellow_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/giga_yellow_spruce.json
@@ -14,11 +14,8 @@
     }
   },
   "leaves_properties": "dtbwg:yellow_spruce",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.35,
   "world_gen_leaf_map_height": 70,
   "features": [
     "conifer_topper",

--- a/src/main/resources/trees/dtbwg/species/holly.json
+++ b/src/main/resources/trees/dtbwg/species/holly.json
@@ -7,11 +7,8 @@
   "growth_rate": 1.1,
   "growth_logic_kit": "dtbwg:tapered",
   "leaves_properties": "dtbwg:holly",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "name": ".*dacite_ridges.*"
   },

--- a/src/main/resources/trees/dtbwg/species/indigo_jacaranda.json
+++ b/src/main/resources/trees/dtbwg/species/indigo_jacaranda.json
@@ -9,11 +9,8 @@
   "growth_logic_kit": "dtbwg:maple",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors": {
-    "cold": 0.75,
-    "snowy": 0.5,
-    "dry": 0.66
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "name": ".*jacaranda.*"
   },

--- a/src/main/resources/trees/dtbwg/species/ironwood.json
+++ b/src/main/resources/trees/dtbwg/species/ironwood.json
@@ -8,10 +8,8 @@
   "soil_longevity": 10,
   "max_branch_radius": 10,
   "leaves_properties": "dtbwg:ironwood",
-  "environment_factors": {
-    "cold": 0.75,
-    "forest": 0.9
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.7,
   "perfect_biomes": {
     "name": "biomeswevegone:.*ironwood.*"
   },

--- a/src/main/resources/trees/dtbwg/species/jacaranda.json
+++ b/src/main/resources/trees/dtbwg/species/jacaranda.json
@@ -7,11 +7,8 @@
   "growth_rate": 1.2,
   "leaves_properties": "dtbwg:jacaranda",
   "growth_logic_kit": "dtbwg:maple",
-  "environment_factors": {
-    "cold": 0.75,
-    "snowy": 0.5,
-    "dry": 0.66
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "name": ".*jacaranda.*"
   },

--- a/src/main/resources/trees/dtbwg/species/mahogany.json
+++ b/src/main/resources/trees/dtbwg/species/mahogany.json
@@ -9,10 +9,8 @@
   "lowest_branch_height": 0,
   "growth_rate": 0.9,
   "leaves_properties": "dtbwg:mahogany",
-  "environment_factors": {
-    "cold": 0.75,
-    "dry": 0.5
-  },
+  "preferred_climate": "tropical",
+  "climate_tolerance": 0.35,
   "mega_species": "dtbwg:mega_mahogany",
   "perfect_biomes": {
     "tag": "#minecraft:is_jungle"

--- a/src/main/resources/trees/dtbwg/species/maple.json
+++ b/src/main/resources/trees/dtbwg/species/maple.json
@@ -7,12 +7,8 @@
   "growth_rate": 0.8,
   "leaves_properties": "dtbwg:maple",
   "growth_logic_kit": "dtbwg:maple",
-  "environment_factors": {
-    "cold": 1.1,
-    "hot": 0.2,
-    "dry": 0.4,
-    "forest": 0.9
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": "biomeswevegone:maple.*"
   },

--- a/src/main/resources/trees/dtbwg/species/mega_blue_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/mega_blue_spruce.json
@@ -17,11 +17,8 @@
   "perfect_biomes": {
     "name": "biomeswevegone:frosted_taiga.*"
   },
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "features": [
     "conifer_topper",
     {

--- a/src/main/resources/trees/dtbwg/species/mega_cypress.json
+++ b/src/main/resources/trees/dtbwg/species/mega_cypress.json
@@ -17,10 +17,8 @@
     }
   },
   "leaves_properties": "dtbwg:cypress",
-  "environment_factors": {
-    "hot": 0.7,
-    "dry": 0.5
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
   "perfect_biomes": {
     "tags": [
       "#c:is_swamp",

--- a/src/main/resources/trees/dtbwg/species/mega_fir.json
+++ b/src/main/resources/trees/dtbwg/species/mega_fir.json
@@ -15,11 +15,8 @@
     }
   },
   "leaves_properties": "dtbwg:fir",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "world_gen_leaf_map_height": 60,
   "perfect_biomes": {
     "tag": "#c:is_coniferous"

--- a/src/main/resources/trees/dtbwg/species/mega_holly.json
+++ b/src/main/resources/trees/dtbwg/species/mega_holly.json
@@ -15,11 +15,8 @@
     }
   },
   "leaves_properties": "dtbwg:holly",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": ".*dacite_ridges.*"
   },

--- a/src/main/resources/trees/dtbwg/species/mega_indigo_jacaranda.json
+++ b/src/main/resources/trees/dtbwg/species/mega_indigo_jacaranda.json
@@ -8,11 +8,8 @@
   "max_branch_radius": 24,
   "leaves_properties": "dtbwg:indigo_jacaranda",
   "growth_logic_kit": "dtbwg:maple",
-  "environment_factors": {
-    "cold": 0.75,
-    "snowy": 0.5,
-    "dry": 0.66
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "name": ".*jacaranda.*"
   },

--- a/src/main/resources/trees/dtbwg/species/mega_jacaranda.json
+++ b/src/main/resources/trees/dtbwg/species/mega_jacaranda.json
@@ -31,5 +31,7 @@
       }
     },
     "bee_nest"
-  ]
+  ],
+  "generate_seed": true,
+  "generate_sapling": true
 }

--- a/src/main/resources/trees/dtbwg/species/mega_jacaranda.json
+++ b/src/main/resources/trees/dtbwg/species/mega_jacaranda.json
@@ -8,11 +8,8 @@
   "max_branch_radius": 24,
   "leaves_properties": "dtbwg:jacaranda",
   "growth_logic_kit": "dtbwg:maple",
-  "environment_factors": {
-    "cold": 0.75,
-    "snowy": 0.5,
-    "dry": 0.66
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "name": ".*jacaranda.*"
   },
@@ -34,15 +31,5 @@
       }
     },
     "bee_nest"
-  ],
-
-  "generate_seed": true,
-  "generate_sapling": true,
-  "sapling_shape": "fat_sapling",
-  "model_overrides": {
-    "sapling": "dynamictrees:block/smartmodel/large_sapling"
-  },
-  "lang_overrides": {
-    "seed": "Mega Jacaranda Pod"
-  }
+  ]
 }

--- a/src/main/resources/trees/dtbwg/species/mega_mahogany.json
+++ b/src/main/resources/trees/dtbwg/species/mega_mahogany.json
@@ -8,10 +8,8 @@
   "soil_longevity": 20,
   "max_branch_radius": 22,
   "leaves_properties": "dtbwg:mahogany",
-  "environment_factors": {
-    "cold": 0.75,
-    "dry": 0.5
-  },
+  "preferred_climate": "tropical",
+  "climate_tolerance": 0.35,
   "perfect_biomes": {
     "tag": "#minecraft:is_jungle"
   },

--- a/src/main/resources/trees/dtbwg/species/mega_orange_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/mega_orange_spruce.json
@@ -14,11 +14,8 @@
     }
   },
   "leaves_properties": "dtbwg:orange_spruce",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "features": [
     "conifer_topper",
     "clear_volume",

--- a/src/main/resources/trees/dtbwg/species/mega_orchard.json
+++ b/src/main/resources/trees/dtbwg/species/mega_orchard.json
@@ -9,11 +9,8 @@
   "max_branch_radius": 24,
   "leaves_properties": "dtbwg:orchard",
   "seed": "dtbwg:orchard_seed",
-  "environment_factors": {
-    "cold": 0.75,
-    "hot": 0.5,
-    "dry": 0.5
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
   "world_gen_leaf_map_height": 60,
   "perfect_biomes": {
     "name": "biomeswevegone:.*orchard.*"

--- a/src/main/resources/trees/dtbwg/species/mega_palm.json
+++ b/src/main/resources/trees/dtbwg/species/mega_palm.json
@@ -1,6 +1,6 @@
 {
   "type": "palm",
-  "family": "palm",
+  "family": "dtbwg:palm",
   "tapering": 0.3,
   "signal_energy": 20.0,
   "growth_rate": 0.9,

--- a/src/main/resources/trees/dtbwg/species/mega_palm.json
+++ b/src/main/resources/trees/dtbwg/species/mega_palm.json
@@ -1,6 +1,6 @@
 {
   "type": "palm",
-  "family": "dtbwg:palm",
+  "family": "palm",
   "tapering": 0.3,
   "signal_energy": 20.0,
   "growth_rate": 0.9,

--- a/src/main/resources/trees/dtbwg/species/mega_palm.json
+++ b/src/main/resources/trees/dtbwg/species/mega_palm.json
@@ -9,11 +9,8 @@
   "max_branch_radius": 12,
   "growth_logic_kit": "dtbwg:diagonal_palm",
   "leaves_properties": "dtbwg:palm",
-  "environment_factors": {
-    "cold": 0.75,
-    "hot": 1.1,
-    "dry": 1.1
-  },
+  "preferred_climate": "tropical",
+  "climate_tolerance": 0.8,
   "transformable": false,
   "perfect_biomes": {
     "tag": "#minecraft:is_beach"

--- a/src/main/resources/trees/dtbwg/species/mega_pine.json
+++ b/src/main/resources/trees/dtbwg/species/mega_pine.json
@@ -9,11 +9,8 @@
   "max_branch_radius": 8,
   "growth_logic_kit": "dtbwg:mega_pine",
   "leaves_properties": "dtbwg:pine",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "world_gen_leaf_map_height": 60,
   "perfect_biomes": {
     "tag": "#c:is_coniferous"

--- a/src/main/resources/trees/dtbwg/species/mega_prairie_oak.json
+++ b/src/main/resources/trees/dtbwg/species/mega_prairie_oak.json
@@ -8,11 +8,8 @@
   "soil_longevity": 16,
   "max_branch_radius": 24,
   "leaves_properties": "dtbwg:prairie_oak",
-  "environment_factors": {
-    "cold": 0.75,
-    "hot": 0.5,
-    "dry": 0.5
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
   "world_gen_leaf_map_height": 60,
   "perfect_biomes": {
     "name": "biomeswevegone:prairie.*"

--- a/src/main/resources/trees/dtbwg/species/mega_rainbow_eucalyptus.json
+++ b/src/main/resources/trees/dtbwg/species/mega_rainbow_eucalyptus.json
@@ -12,10 +12,8 @@
   "max_branch_radius": 22,
   "growth_logic_kit": "dtbwg:mega_rainbow_eucalyptus",
   "leaves_properties": "dtbwg:rainbow_eucalyptus",
-  "environment_factors": {
-    "snowy": 0.5,
-    "dry": 0.75
-  },
+  "preferred_climate": "tropical",
+  "climate_tolerance": 0.35,
   "perfect_biomes": {
     "type": "#minecraft:is_jungle"
   },

--- a/src/main/resources/trees/dtbwg/species/mega_red_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/mega_red_spruce.json
@@ -14,11 +14,8 @@
     }
   },
   "leaves_properties": "dtbwg:red_spruce",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "features": [
     "conifer_topper",
     "clear_volume",

--- a/src/main/resources/trees/dtbwg/species/mega_skyris.json
+++ b/src/main/resources/trees/dtbwg/species/mega_skyris.json
@@ -8,10 +8,8 @@
   "soil_longevity": 20,
   "max_branch_radius": 14,
   "leaves_properties": "dtbwg:skyris",
-  "environment_factors": {
-    "hot": 0.5,
-    "dry": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.45,
   "perfect_biomes": {
     "name": "biomeswevegone:.*skyris.*"
   },

--- a/src/main/resources/trees/dtbwg/species/mega_willow.json
+++ b/src/main/resources/trees/dtbwg/species/mega_willow.json
@@ -13,10 +13,8 @@
       "canopy_depth": 6
     }
   },
-  "environment_factors": {
-    "snowy": 0.75,
-    "dry": 0.5
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "tag": "#c:is_swamp"
   },

--- a/src/main/resources/trees/dtbwg/species/mega_yellow_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/mega_yellow_spruce.json
@@ -14,11 +14,8 @@
     }
   },
   "leaves_properties": "dtbwg:yellow_spruce",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "features": [
     "conifer_topper",
     "clear_volume",

--- a/src/main/resources/trees/dtbwg/species/northern_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/northern_spruce.json
@@ -13,10 +13,8 @@
     }
   },
   "leaves_properties": "dtbwg:northern_spruce",
-  "environment_factors": {
-    "hot": 0.50,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "tag": "#c:is_coniferous"
   },

--- a/src/main/resources/trees/dtbwg/species/orange_birch.json
+++ b/src/main/resources/trees/dtbwg/species/orange_birch.json
@@ -8,12 +8,8 @@
   "leaves_properties": "dtbwg:orange_birch",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors": {
-    "cold": 0.75,
-    "hot": 0.5,
-    "dry": 0.5,
-    "forest": 1.05
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.45,
   "perfect_biomes": {
     "name": ".*howling_peaks.*"
   },

--- a/src/main/resources/trees/dtbwg/species/orange_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/orange_spruce.json
@@ -7,11 +7,8 @@
   "leaves_properties": "dtbwg:orange_spruce",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": "biomeswevegone:.*crimson_tundra.*"
   },

--- a/src/main/resources/trees/dtbwg/species/orchard.json
+++ b/src/main/resources/trees/dtbwg/species/orchard.json
@@ -8,11 +8,8 @@
   "leaves_properties": "dtbwg:orchard",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors": {
-    "cold": 0.75,
-    "hot": 0.5,
-    "dry": 0.5
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
   "perfect_biomes": {
     "name": "biomeswevegone:.*orchard.*"
   },

--- a/src/main/resources/trees/dtbwg/species/palm.json
+++ b/src/main/resources/trees/dtbwg/species/palm.json
@@ -1,6 +1,6 @@
 {
   "type": "palm",
-  "family": "dtbwg:palm",
+  "family": "palm",
   "tapering": 0.2,
   "signal_energy": 10.0,
   "growth_rate": 0.8,

--- a/src/main/resources/trees/dtbwg/species/palm.json
+++ b/src/main/resources/trees/dtbwg/species/palm.json
@@ -1,6 +1,6 @@
 {
   "type": "palm",
-  "family": "palm",
+  "family": "dtbwg:palm",
   "tapering": 0.2,
   "signal_energy": 10.0,
   "growth_rate": 0.8,

--- a/src/main/resources/trees/dtbwg/species/palm.json
+++ b/src/main/resources/trees/dtbwg/species/palm.json
@@ -8,11 +8,8 @@
   "max_branch_radius": 8,
   "growth_logic_kit": "dtbwg:diagonal_palm",
   "leaves_properties": "dtbwg:palm",
-  "environment_factors": {
-    "cold": 0.75,
-    "hot": 1.1,
-    "dry": 1.1
-  },
+  "preferred_climate": "arid",
+  "climate_tolerance": 0.8,
   "mega_species": "dtbwg:mega_palm",
   "transformable": false,
   "perfect_biomes": {

--- a/src/main/resources/trees/dtbwg/species/palo_verde.json
+++ b/src/main/resources/trees/dtbwg/species/palo_verde.json
@@ -6,11 +6,8 @@
   "lowest_branch_height": 2,
   "growth_rate": 0.7,
   "leaves_properties": "dtbwg:palo_verde",
-  "environment_factors": {
-    "cold": 0.25,
-    "nether": 0.75,
-    "wet": 0.75
-  },
+  "preferred_climate": "arid",
+  "climate_tolerance": 0.25,
   "perfect_biomes": {
     "tag": "#(minecraft:is_badlands)|(c:is_desert)"
   },

--- a/src/main/resources/trees/dtbwg/species/pine.json
+++ b/src/main/resources/trees/dtbwg/species/pine.json
@@ -7,10 +7,8 @@
   "growth_rate": 0.9,
   "growth_logic_kit": "dtbwg:thin_conifer",
   "leaves_properties": "dtbwg:pine",
-  "environment_factors": {
-    "hot": 0.50,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.35,
   "perfect_biomes": {
     "tag": "#c:is_coniferous"
   },

--- a/src/main/resources/trees/dtbwg/species/prairie_oak.json
+++ b/src/main/resources/trees/dtbwg/species/prairie_oak.json
@@ -5,11 +5,8 @@
   "growth_rate": 0.8,
   "lowest_branch_height": 4,
   "leaves_properties": "dtbwg:prairie_oak",
-  "environment_factors": {
-    "cold": 0.75,
-    "hot": 0.5,
-    "dry": 0.5
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
   "perfect_biomes": {
     "name": "biomeswevegone:prairie.*"
   },

--- a/src/main/resources/trees/dtbwg/species/rainbow_eucalyptus.json
+++ b/src/main/resources/trees/dtbwg/species/rainbow_eucalyptus.json
@@ -15,10 +15,8 @@
     }
   },
   "leaves_properties": "dtbwg:rainbow_eucalyptus",
-  "environment_factors": {
-    "snowy": 0.5,
-    "dry": 0.75
-  },
+  "preferred_climate": "tropical",
+  "climate_tolerance": 0.35,
   "mega_species": "dtbwg:mega_rainbow_eucalyptus",
   "perfect_biomes": {
     "tag": "#minecraft:is_jungle"

--- a/src/main/resources/trees/dtbwg/species/red_maple.json
+++ b/src/main/resources/trees/dtbwg/species/red_maple.json
@@ -9,12 +9,8 @@
   "growth_logic_kit": "dtbwg:maple",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors": {
-    "cold": 1.1,
-    "hot": 0.2,
-    "dry": 0.4,
-    "forest": 0.9
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": "biomeswevegone:maple.*"
   },

--- a/src/main/resources/trees/dtbwg/species/red_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/red_spruce.json
@@ -7,11 +7,8 @@
   "leaves_properties": "dtbwg:red_spruce",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": "biomeswevegone:crimson_tundra"
   },

--- a/src/main/resources/trees/dtbwg/species/redwood.json
+++ b/src/main/resources/trees/dtbwg/species/redwood.json
@@ -9,11 +9,8 @@
   "max_branch_radius": 24,
   "growth_logic_kit": "dtbwg:redwood",
   "leaves_properties": "dtbwg:redwood",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "forest": 1.05
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
   "world_gen_leaf_map_height": 64,
   "common_override": {
     "name": ".*redwood.*"

--- a/src/main/resources/trees/dtbwg/species/silver_maple.json
+++ b/src/main/resources/trees/dtbwg/species/silver_maple.json
@@ -9,12 +9,8 @@
   "growth_logic_kit": "dtbwg:maple",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors": {
-    "cold": 1.1,
-    "hot": 0.2,
-    "dry": 0.4,
-    "forest": 0.9
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": "biomeswevegone:maple.*"
   },

--- a/src/main/resources/trees/dtbwg/species/skyris.json
+++ b/src/main/resources/trees/dtbwg/species/skyris.json
@@ -6,10 +6,8 @@
   "lowest_branch_height": 6,
   "growth_rate": 0.7,
   "leaves_properties": "dtbwg:skyris",
-  "environment_factors": {
-    "hot": 0.5,
-    "dry": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.45,
   "perfect_biomes": {
     "name": "biomeswevegone:.*skyris.*"
   },

--- a/src/main/resources/trees/dtbwg/species/small_cika.json
+++ b/src/main/resources/trees/dtbwg/species/small_cika.json
@@ -8,11 +8,8 @@
   "soil_longevity": 3,
   "growth_logic_kit": "conifer",
   "leaves_properties": "dtbwg:cika",
-  "environment_factors": {
-    "hot": 0.8,
-    "dry": 0.75,
-    "wet": 0.9
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.45,
   "seed": "dtbwg:cika_seed",
   "sapling_name": "cika_sapling",
   "perfect_biomes": {

--- a/src/main/resources/trees/dtbwg/species/small_redwood.json
+++ b/src/main/resources/trees/dtbwg/species/small_redwood.json
@@ -9,11 +9,8 @@
   "max_branch_radius": 24,
   "growth_logic_kit": "dtbwg:small_redwood",
   "leaves_properties": "dtbwg:redwood",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
   "seed": "dtbwg:redwood_seed",
   "sapling_name": "redwood_sapling",
   "perfect_biomes": {

--- a/src/main/resources/trees/dtbwg/species/sparse_willow.json
+++ b/src/main/resources/trees/dtbwg/species/sparse_willow.json
@@ -8,10 +8,8 @@
   "leaves_properties": "dtbwg:sparse_willow",
   "growth_logic_kit": "dtbwg:willow",
   "does_rot": false,
-  "environment_factors": {
-    "snowy": 0.75,
-    "dry": 0.5
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "tag": "#c:is_swamp"
   },

--- a/src/main/resources/trees/dtbwg/species/sparse_witch_hazel.json
+++ b/src/main/resources/trees/dtbwg/species/sparse_witch_hazel.json
@@ -9,10 +9,8 @@
   "leaves_properties": "dtbwg:sparse_witch_hazel",
   "growth_logic_kit": "dtbwg:ebony",
   "does_rot": false,
-  "environment_factors": {
-    "snowy": 0.75,
-    "dry": 0.5
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
   "perfect_biomes": {
     "name": ".*witch.*"
   },

--- a/src/main/resources/trees/dtbwg/species/spirit.json
+++ b/src/main/resources/trees/dtbwg/species/spirit.json
@@ -14,10 +14,8 @@
   "leaves_properties": "dtbwg:spirit",
   "growth_logic_kit": "dark_oak",
   "roots_growth_logic_kit": "mangrove_roots",
-  "environment_factors": {
-    "hot": 0.75,
-    "dry": 0.2
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.3,
   "perfect_biomes": { "tag": "#c:is_swamp" },
   "drop_seeds": true,
   "primitive_sapling": "biomeswevegone:spirit_sapling",

--- a/src/main/resources/trees/dtbwg/species/tall_blue_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/tall_blue_spruce.json
@@ -14,12 +14,8 @@
   },
   "leaves_properties": "dtbwg:blue_spruce",
   "seed": "dtbwg:blue_spruce_seed",
-  "environment_factors": {
-    "cold": 1.1,
-    "hot": 0.2,
-    "dry": 0.4,
-    "forest": 0.9
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": "biomeswevegone:frosted_taiga.*"
   },

--- a/src/main/resources/trees/dtbwg/species/tall_cherry.json
+++ b/src/main/resources/trees/dtbwg/species/tall_cherry.json
@@ -7,11 +7,8 @@
   "growth_rate": 0.8,
   "max_branch_radius": 10,
   "leaves_properties": "cherry",
-  "environment_factors": {
-    "hot": 0.5,
-    "dry": 0.5,
-    "forest": 1.05
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "name": "biomeswevegone:sakura.*"
   },

--- a/src/main/resources/trees/dtbwg/species/tall_fir.json
+++ b/src/main/resources/trees/dtbwg/species/tall_fir.json
@@ -7,11 +7,8 @@
   "growth_rate": 1.1,
   "growth_logic_kit": "conifer",
   "leaves_properties": "dtbwg:fir",
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "tag": "#c:is_coniferous"
   },

--- a/src/main/resources/trees/dtbwg/species/tall_mahogany.json
+++ b/src/main/resources/trees/dtbwg/species/tall_mahogany.json
@@ -12,10 +12,8 @@
     }
   },
   "leaves_properties": "dtbwg:mahogany",
-  "environment_factors": {
-    "cold": 0.75,
-    "dry": 0.5
-  },
+  "preferred_climate": "tropical",
+  "climate_tolerance": 0.35,
   "perfect_biomes": {
     "tag": "#minecraft:is_jungle"
   },

--- a/src/main/resources/trees/dtbwg/species/tall_orange_birch.json
+++ b/src/main/resources/trees/dtbwg/species/tall_orange_birch.json
@@ -8,12 +8,8 @@
   "soil_longevity": 12,
   "leaves_properties": "dtbwg:orange_birch",
   "seed": "dtbwg:orange_birch_seed",
-  "environment_factors": {
-    "cold": 0.75,
-    "hot": 0.5,
-    "dry": 0.5,
-    "forest": 1.05
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.45,
   "common_override": {
     "name": "minecraft:tall_birch.*"
   },

--- a/src/main/resources/trees/dtbwg/species/tall_orange_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/tall_orange_spruce.json
@@ -14,12 +14,8 @@
   },
   "leaves_properties": "dtbwg:orange_spruce",
   "seed": "dtbwg:orange_spruce_seed",
-  "environment_factors": {
-    "cold": 1.1,
-    "hot": 0.2,
-    "dry": 0.4,
-    "forest": 0.9
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": "biomeswevegone:.*crimson_tundra.*"
   },

--- a/src/main/resources/trees/dtbwg/species/tall_orchard.json
+++ b/src/main/resources/trees/dtbwg/species/tall_orchard.json
@@ -7,11 +7,8 @@
   "lowest_branch_height": 12,
   "leaves_properties": "dtbwg:orchard",
   "seed": "dtbwg:orchard_seed",
-  "environment_factors": {
-    "cold": 0.75,
-    "hot": 0.5,
-    "dry": 0.5
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
   "perfect_biomes": {
     "name": "biomeswevegone:.*orchard.*"
   },

--- a/src/main/resources/trees/dtbwg/species/tall_red_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/tall_red_spruce.json
@@ -14,12 +14,8 @@
   },
   "leaves_properties": "dtbwg:red_spruce",
   "seed": "dtbwg:red_spruce_seed",
-  "environment_factors": {
-    "cold": 1.1,
-    "hot": 0.2,
-    "dry": 0.4,
-    "forest": 0.9
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": "biomeswevegone:crimson_tundra"
   },

--- a/src/main/resources/trees/dtbwg/species/tall_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/tall_spruce.json
@@ -1,39 +1,35 @@
 {
-  "family": "spruce",
-  "tapering": 0.2,
-  "signal_energy": 25.0,
-  "up_probability": 5,
-  "lowest_branch_height": 8,
-  "growth_rate": 0.9,
-  "soil_longevity": 8,
-  "growth_logic_kit": {
-    "name": "conifer",
-    "properties": {
-      "energy_divisor": 4
-    }
-  },
-  "leaves_properties": "spruce",
-  "environment_factors": {
-    "cold": 1.1,
-    "hot": 0.2,
-    "dry": 0.4,
-    "forest": 0.9
-  },
-  "perfect_biomes": {
-    "name": "biomeswevegone:dacite_ridges"
-  },
-  "mega_species": "mega_spruce",
-  "features": [
-    "conifer_topper",
-    "podzol",
-    "bottom_flare",
-    {
-      "name": "roots",
-      "properties": {
-        "min_trunk_radius": 8,
-        "scale_factor": 12
-      }
-    }
+    "family": "spruce",
+    "tapering": 0.2,
+    "signal_energy": 25.0,
+    "up_probability": 5,
+    "lowest_branch_height": 8,
+    "growth_rate": 0.9,
+    "soil_longevity": 8,
+    "growth_logic_kit": {
+        "name": "conifer",
+        "properties": {
+            "energy_divisor": 4
+        }
+    },
+    "leaves_properties": "spruce",
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
+    "perfect_biomes": {
+        "name": "biomeswevegone:dacite_ridges"
+    },
+    "mega_species": "mega_spruce",
+    "features": [
+        "conifer_topper",
+        "podzol",
+        "bottom_flare",
+        {
+            "name": "roots",
+            "properties": {
+                "min_trunk_radius": 8,
+                "scale_factor": 12
+            }
+        }
   ],
   "generate_seed": false,
   "generate_sapling": false

--- a/src/main/resources/trees/dtbwg/species/tall_yellow_birch.json
+++ b/src/main/resources/trees/dtbwg/species/tall_yellow_birch.json
@@ -8,12 +8,8 @@
   "soil_longevity": 12,
   "leaves_properties": "dtbwg:yellow_birch",
   "seed": "dtbwg:yellow_birch_seed",
-  "environment_factors": {
-    "cold": 0.75,
-    "hot": 0.5,
-    "dry": 0.5,
-    "forest": 1.05
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.4,
   "common_override": {
     "name": "minecraft:tall_birch.*"
   },

--- a/src/main/resources/trees/dtbwg/species/tapered_oak.json
+++ b/src/main/resources/trees/dtbwg/species/tapered_oak.json
@@ -7,10 +7,8 @@
   "growth_rate": 0.9,
   "growth_logic_kit": "dtbwg:tapered",
   "leaves_properties": "dtbwg:tapered_oak",
-  "environment_factors": {
-    "hot": 0.75,
-    "dry": 0.50
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.4,
   "common_override": {
     "name": "biomeswevegone:fragment_jungle"
   },

--- a/src/main/resources/trees/dtbwg/species/white_mangrove.json
+++ b/src/main/resources/trees/dtbwg/species/white_mangrove.json
@@ -10,10 +10,8 @@
   "growth_rate": 0.6,
   "leaves_properties": "dtbwg:white_mangrove",
   "roots_growth_logic_kit": "mangrove_roots",
-  "environment_factors": {
-    "cold": 0.75,
-    "dry": 0.2
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.25,
   "perfect_biomes": { "tag": "#c:is_swamp" },
   "primitive_sapling": "biomeswevegone:white_mangrove_sapling",
   "sapling_shape": "slim_sapling",

--- a/src/main/resources/trees/dtbwg/species/white_sakura.json
+++ b/src/main/resources/trees/dtbwg/species/white_sakura.json
@@ -7,18 +7,14 @@
   "growth_rate": 0.8,
   "max_branch_radius": 10,
   "leaves_properties": "dtbwg:white_sakura",
-  "environment_factors": {
-    "cold": 1.1,
-    "hot": 0.2,
-    "dry": 0.4,
-    "forest": 0.9
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": "biomeswevegone:sakura.*"
   },
   "primitive_sapling": "biomeswevegone:white_sakura_sapling",
   "features": [
-    "bee_nest"
+        "bee_nest"
   ],
   "lang_overrides": {
     "seed": "White Sakura Pit"

--- a/src/main/resources/trees/dtbwg/species/willow.json
+++ b/src/main/resources/trees/dtbwg/species/willow.json
@@ -6,10 +6,8 @@
   "lowest_branch_height": 6,
   "growth_rate": 0.8,
   "growth_logic_kit": "dtbwg:willow",
-  "environment_factors": {
-    "snowy": 0.75,
-    "dry": 0.5
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "tag": "#c:is_swamp"
   },

--- a/src/main/resources/trees/dtbwg/species/witch_hazel.json
+++ b/src/main/resources/trees/dtbwg/species/witch_hazel.json
@@ -8,10 +8,8 @@
   "soil_longevity": 20,
   "leaves_properties": "dtbwg:witch_hazel",
   "growth_logic_kit": "dtbwg:ebony",
-  "environment_factors": {
-    "snowy": 0.75,
-    "dry": 0.5
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.35,
   "perfect_biomes": {
     "name": ".*witch.*"
   },

--- a/src/main/resources/trees/dtbwg/species/yellow_birch.json
+++ b/src/main/resources/trees/dtbwg/species/yellow_birch.json
@@ -8,12 +8,8 @@
   "leaves_properties": "dtbwg:yellow_birch",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors": {
-    "cold": 0.75,
-    "hot": 0.5,
-    "dry": 0.5,
-    "forest": 1.05
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "name": ".*howling_peaks.*"
   },

--- a/src/main/resources/trees/dtbwg/species/yellow_sakura.json
+++ b/src/main/resources/trees/dtbwg/species/yellow_sakura.json
@@ -9,12 +9,8 @@
   "leaves_properties": "dtbwg:yellow_sakura",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors": {
-    "cold": 1.1,
-    "hot": 0.2,
-    "dry": 0.4,
-    "forest": 0.9
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": {
     "name": "biomeswevegone:sakura.*"
   },

--- a/src/main/resources/trees/dtbwg/species/yellow_spruce.json
+++ b/src/main/resources/trees/dtbwg/species/yellow_spruce.json
@@ -7,11 +7,8 @@
   "leaves_properties": "dtbwg:yellow_spruce",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors": {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.35,
   "primitive_sapling": "biomeswevegone:yellow_spruce_sapling",
   "mega_species": "dtbwg:mega_yellow_spruce",
   "features": [

--- a/src/main/resources/trees/dtbwg/species/yucca.json
+++ b/src/main/resources/trees/dtbwg/species/yucca.json
@@ -6,10 +6,8 @@
   "leaves_properties": "dtbwg:yucca",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors": {
-    "wet": 0.75,
-    "cold": 0.75
-  },
+  "preferred_climate": "arid",
+  "climate_tolerance": 0.45,
   "perfect_biomes": {
     "tags": [
       "#c:is_desert",

--- a/src/main/resources/trees/dtbwg/species/zelkova.json
+++ b/src/main/resources/trees/dtbwg/species/zelkova.json
@@ -7,10 +7,8 @@
   "growth_rate": 0.9,
   "growth_logic_kit": "dtbwg:zelkova",
   "leaves_properties": "dtbwg:zelkova",
-  "environment_factors": {
-    "hot": 0.50,
-    "wet": 0.75
-  },
+  "preferred_climate": "temperate",
+  "climate_tolerance": 0.4,
   "perfect_biomes": {
     "name": ".*zelkova.*"
   },

--- a/src/main/resources/trees/dynamictrees/species/mega_spruce.json
+++ b/src/main/resources/trees/dynamictrees/species/mega_spruce.json
@@ -16,14 +16,11 @@
   "leaves_properties": "spruce",
   "generate_seed": true,
   "generate_sapling": true,
-  "environment_factors" : {
-    "hot": 0.50,
-    "dry": 0.25,
-    "wet": 0.75
-  },
+  "preferred_climate": "cold",
+  "climate_tolerance": 0.3,
   "perfect_biomes": { "name": "minecraft:old_growth_(pine|spruce)_taiga" },
   "common_override": { "name": "minecraft:old_growth_(pine|spruce)_taiga" },
-  "features" : [
+  "features": [
     "conifer_topper",
     {
       "name": "mound",
@@ -41,5 +38,6 @@
   "lang_overrides": {
     "seed": "Mega Spruce Cone"
   },
+
   "mega_species": "dtbwg:giga_spruce"
 }


### PR DESCRIPTION
Updated dependencies to replace `environment_factors` after seeing these error logs:
```log
[25Jul2026 09:04:23.771] [Render thread/WARN] [com.dtteam.dynamictrees.treepack.loader.SpeciesResourceLoader/]: The "environment_factors" property has been removed. Use "preferred_climate" instead! Species dynamictrees:mega_spruce.
[25Jul2026 09:04:23.773] [Render thread/WARN] [com.dtteam.dynamictrees.treepack.loader.SpeciesResourceLoader/]: The "environment_factors" property has been removed. Use "preferred_climate" instead! Species dynamictrees:dark_oak.
[25Jul2026 09:04:23.773] [Render thread/WARN] [Dynamic Trees/]: Warning whilst loading type "Species" with name "dynamictrees:dark_oak": [features] Gen Feature couldn't be found from input "{"name":"huge_mushrooms","properties":{"max_mushrooms":1,"max_attempts":3}}".
[25Jul2026 09:04:23.779] [Render thread/WARN] [com.dtteam.dynamictrees.treepack.loader.SpeciesResourceLoader/]: The "environment_factors" property has been removed. Use "preferred_climate" instead! Species dtbop:yellow_maple.
[25Jul2026 09:04:23.779] [Render thread/WARN] [com.dtteam.dynamictrees.treepack.loader.SpeciesResourceLoader/]: The "environment_factors" property has been removed. Use "preferred_climate" instead! Species dtbop:willow.
```

Error messages confirmed to go away after update. I tried to match the `preferred_climate` and `climate_tolerance` values to the intent of the `environment_factors`.